### PR TITLE
feat: add flask backend and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+venv/
+__pycache__/
+*.pyc
+.DS_Store
+.env

--- a/app.py
+++ b/app.py
@@ -1,0 +1,23 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+# Temporary storage for palette
+palettes = []
+
+@app.route('/')
+def home():
+    return "Welcome to the Colors App API!"
+
+@app.route('/palettes', methods=['GET'])
+def get_palettes():
+    return jsonify(palettes), 200
+
+@app.route('/palettes', methods=['POST'])
+def add_palette():
+    palette = request.json
+    palettes.append(palette)
+    return jsonify(palette), 201
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
Add Flask Backend
Description
This pull request adds a basic Flask backend to the colors-app project. The new backend includes routes for managing color palettes.

Changes
app.py: Created a new Flask application with the following endpoints:
GET /palettes: Returns a list of all palettes.
POST /palettes: Adds a new palette to the list.
.gitignore: Added to exclude the venv directory.
How to Test
Setup:
Create and activate a virtual environment: python -m venv venv and source venv/bin/activate
Install Flask: pip install flask
Run the server:
Start the Flask server: python app.py
Test endpoints:
GET /palettes: Use curl http://127.0.0.1:5000/palettes to check for an empty list.
POST /palettes: Use curl -X POST http://127.0.0.1:5000/palettes -H "Content-Type: application/json" -d '{"name": "My Palette", "colors": ["#FFFFFF", "#000000"]}' to add a new palette.
Verify the new palette: Use curl http://127.0.0.1:5000/palettes to check if the new palette is added.